### PR TITLE
Removed .key from cacheCloudToken

### DIFF
--- a/lib/data/cache/auth.js
+++ b/lib/data/cache/auth.js
@@ -58,7 +58,7 @@ export function retrieveCloudToken() {
 
 export function cacheCloudToken(token) {
     return new Promise((resolve, reject) => {
-        Chunky.Platform.storage.setItem(Config.CLOUD_TOKEN_CACHE_KEY, `${token.key}`, (error) => {
+        Chunky.Platform.storage.setItem(Config.CLOUD_TOKEN_CACHE_KEY, `${token}`, (error) => {
 
             if (error) {
                 // Something went wrong when saving the token


### PR DESCRIPTION
There is no key attribute for the token so we get a warning