### PR TITLE
Changed the way we cache the token. Before we cached only the key, no…

### DIFF
--- a/lib/data/cache/auth.js
+++ b/lib/data/cache/auth.js
@@ -16,7 +16,7 @@ export function retrieveAuthToken() {
 
 export function cacheAuthToken(token) {
     return new Promise((resolve, reject) => {
-        Chunky.Platform.storage.setItem(Config.AUTH_TOKEN_CACHE_KEY, `${token.key}`, (error) => {
+        Chunky.Platform.storage.setItem(Config.AUTH_TOKEN_CACHE_KEY, `${token}`, (error) => {
 
             if (error) {
                 // Something went wrong when saving the token


### PR DESCRIPTION
…w it is cache the whole object. This was changed because the APIs fields will differ.